### PR TITLE
remove cast from getProjectBranches

### DIFF
--- a/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
+++ b/src/main/java/com/dabsquared/gitlabjenkins/GitLabPushTrigger.java
@@ -559,11 +559,11 @@ public class GitLabPushTrigger extends Trigger<Job<?, ?>> {
         }
 
         private List<String> getProjectBranches(final Job<?, ?> job) throws IOException, IllegalStateException {
-            if (!(job instanceof AbstractProject<?, ?>)) {
+            /*if (!(job instanceof AbstractProject<?, ?>)) {
                 return Lists.newArrayList();
-            }
+            }*/
 
-            final URIish sourceRepository = getSourceRepoURLDefault((AbstractProject<?, ?>) job);
+            final URIish sourceRepository = getSourceRepoURLDefault(job);
             if (sourceRepository == null) {
                 throw new IllegalStateException(Messages.GitLabPushTrigger_NoSourceRepository());
             }


### PR DESCRIPTION
WorkflowJob doesn't implement AbstractProject, so this cast was breaking the getProjectBranches method.

Not sure if this breaks other things elsewhere.

The best fix is probably to change WorkflowJob to implement AbstractProject, if that isn't too much work
